### PR TITLE
doc(BUD-1): The great GitHub migration

### DIFF
--- a/buds/bud-1.md
+++ b/buds/bud-1.md
@@ -1,9 +1,3 @@
-<!----------------------------------------------------------------------
-This is a template for creating new BUDs (Blueprints for Upcoming
-Development). Copy this file to buds/bud-[number].md (or use TBD for the
-number initially) and fill in each section.
------------------------------------------------------------------------>
-
 ---
 bud: 1 (TBD)
 title: The great GitHub migration
@@ -16,71 +10,143 @@ pr: 4
 ## Summary
 
 We have been given the green light to move the Topiary repository from
-the Tweag GitHub organisation to our new Topiary organisation, providing
-we maintain appropriate branding. The move also gives us an opportunity
-to break out some of the peripheral subcomponents of the Topiary
-repository into their own, dedicated repositories.
+the Tweag GitHub organisation to our newly acquired `@topiary`
+organisation, providing we maintain appropriate branding. The move also
+gives us an opportunity to break out some of the peripheral
+subcomponents of the Topiary repository into their own, dedicated
+repositories.
 
 ## Motivation
 
 - Having all Topiary repositories under one organisation is clearer and
   aids discovery, at the expense of current users having to update links
-  and remotes, etc.
+  and (maybe) remotes, etc.
 
-- The Topiary website is orthogonal to the Topiary codebase, so should
-  certainly be broken out into its own repository. Similar arguments can
-  be made for:
+- Many Topiary components are not directly synchronised with the Topiary
+  codebase and, arguably, not relevant to downstream users:
 
-  - The Topiary playground: Not currently under active development, but
-    effectively another client of the Topiary core library.
+  - The Topiary website is a simple landing page, with links to the
+    Topiary Book and playground. The only connection it has to the main
+    Topiary codebase is that these components are built and deployed by
+    the same CI.
 
-  - The Topiary Book and manpages: These should be synchronised with the
-    codebase, so the decoupling argument is weaker, but keeping them
-    separate _may_ motivate better code documentation, keeping the Book
-    as user documentation.
+  - The Topiary playground is not currently under active development,
+    but is effectively an orthogonal client of the Topiary core library,
+    targeting WASM. It is a dependent on the Topiary codebase, but there
+    is no implicit synchronisation and can be developed independently.
 
-  - [topiary-opam][https://github.com/tweag/topiary-opam]: This is
-    separate from the Topiary repository, but will probably need to be
-    updated if the migration goes ahead and, indeed, is a target for
-    migration itself.
+  - The Topiary Book and manpages: This is less clear. The Topiary Book
+    is the user documentation for Topiary, including usage of the CLI
+    frontend which _is_ a part of the Topiary codebase. Moreover, the
+    manpages -- which are generated from a subset of the Book -- are
+    specific to the CLI. Finally, the majority of the Book documents the
+    formatting capture names, which again are inherent to the Topiary
+    core library.
 
-There may be infrastructural changes required for correctly migrate
-(e.g., DNS, Cachix, etc.)
+    As a compromise, the Topiary Book and manpages should remain part of
+    the Topiary codebase. However, the mdBook pre- and post-processor
+    (`mdbook-manmunge`) used to help _generate_ the manpages should be
+    factored out into its own repository.
+
+  - [`topiary-opam`](https://github.com/tweag/topiary-opam): This is
+    separate from the Topiary repository, but is also a target for
+    migration for the same reasons. Moreover, having it under the same
+    roof will remind us to keep it up-to-date with Topiary releases.
 
 ## Proposed design
 
-{TODO: Still under discussion}
+1. Confirm Topiary core team have necessary access to all relevant
+   resources.
+
+2. Announce the migration on Discord, with a reasonable amount of lead
+   time and an expectation of the downtime.
+
+3. Migrate `tweag/topiary` and `tweag/topiary-opam` to the `@topiary`
+   organisation.
+
+4. Break out subcomponents:
+
+   - `mdbook-manmunge` and update Topiary manpage generator to use new
+     dependency.
+
+   - Topiary playground, updating its CI to confirm the build.
+
+   - Topiary website, updating to use the new sources for the Topiary
+     repository, Book and playground.
+
+5. Announce completed migration on Discord.
+
+### Infrastructure changes
+
+- The main Topiary repository will need its Cachix credentials set to
+  point to the original Tweag Cachix account.
+
+- The Topiary website's CI will need to change to build/retrieve all
+  upstream dependencies (the Topiary Book and playground) before
+  deployment.
+
+- The GitHub Pages configuration will need to be changed appropriately,
+  for the Topiary website.
+
+- The Tweag DNS records will need to be updated to point to the new
+  GitHub Pages endpoint.
 
 ## Alternatives considered
 
-Leave the Topiary repository where it is; i.e., do nothing. {TODO: Still
-under discussion}
+Leave the Topiary repository where it is; i.e., do nothing. However,
+there is now a precedent at Tweag to move its open source projects into
+their own organisations (e.g., [`nickel-lang/nickel`](https://github.com/nickel-lang/nickel)
+and [`bazel-contrib/rules_img`](https://github.com/bazel-contrib/rules_img)).
+
+Regarding Cachix, they offer a 5GB free plan for open source projects,
+which could be used instead of the Tweag account. This may be a good
+long-term option.
 
 ## Drawbacks
 
-- Website downtime during the migration
-- Current users would have to update links and remotes
+- Website downtime during the migration.
+- Current users would have to update links.
+  - GitHub redirects old remotes, so providing `tweag/topiary` isn't
+    recreated, this should not be an issue.
 - The decoupling proposal would increase the complexity (warranting a
-  multiphase migration) and probably increase the website downtime
-- DNS changes take a while to action, which will also impact website
-  downtime
-- We risk losing access to Tweag infrastructure (e.g., Cachix)
+  multiphase migration) and probably increase the website downtime.
+- DNS and other infra changes take a while to action, which will also
+  impact website downtime.
 
 ## Backwards compatibility
 
-If current users don't update links/remotes, that may be confusing for
-them. We can mitigate this to a certain extent by broadcasting it on
-Discord. GitHub _may_ keep the old remote active for a limited time, and
-display a warning, like it does when repository names change.
+If current users don't update links, that may be confusing for them. We
+can mitigate this to a certain extent by broadcasting it on Discord.
+GitHub will keep the old remote active for a limited time, and display a
+warning, like it does when repository names change.
 
 ## Testing strategy
 
-{TODO: Still under discussion}
+- Check CI jobs all run to successful completion.
+
+- Check updated DNS records.
+
+- Manual inspection of migrated website. (The website is small enough to
+  make this preferable to automating the process.)
 
 ## Documentation impact
 
-{TODO: Still under discussion}
+Documentation will remain under the Topiary repository, so there will be
+no impact.
 
 ## Unresolved questions
 
-{TODO: Still under discussion}
+- For the broken out subcomponents that are dependencies of the website,
+  should we:
+
+  1. Build the subcomponents in the broken out repository's CI and let
+     the website pull in the latest release, when its CI builds?
+
+  2. Or: When the website's CI builds, checkout the appropriate
+     subcomponents and build them as subtasks?
+
+  This question is focused on the Topiary playground.
+
+  For the Topiary Book, option (2) is probably the only appropriate
+  strategy because the Book is not manifested as a release artefact (and
+  cannot be without interfering with Topiary's `dist` release process).

--- a/buds/bud-1.md
+++ b/buds/bud-1.md
@@ -150,3 +150,10 @@ no impact.
   For the Topiary Book, option (2) is probably the only appropriate
   strategy because the Book is not manifested as a release artefact (and
   cannot be without interfering with Topiary's `dist` release process).
+
+- Relatedly, when dependencies of the website are changed, how can we
+  trigger a new build of the website (e.g., if the Topiary Book is
+  updated, that should reflected on the website)? I believe GitHub
+  Actions _can_ trigger other actions across repositories, but this
+  needs to be carefully looked into; we shouldn't expect contributors to
+  have to make cousin PRs in separate repositories manually.

--- a/buds/bud-1.md
+++ b/buds/bud-1.md
@@ -91,6 +91,41 @@ repositories.
 - The Tweag DNS records will need to be updated to point to the new
   GitHub Pages endpoint.
 
+### Build and deployment strategy
+
+The broken-out subcomponents (the Topiary playground and Book) will be
+integrated with the Topiary website using cross-repository GitHub Action
+triggers via `repository_dispatch` events with a PAT. This allows
+changes to propagate automatically without requiring manual cousin PRs.
+
+#### Topiary playground
+
+- **Build location**: Playground repository's own CI
+- **Artefact storage**: GitHub releases
+- **Versioning**: Release builds only
+- **Website trigger**: When a playground release is published, trigger
+  the website CI via `repository_dispatch` to pull in the new release
+  artefacts
+
+Since the playground is currently dormant and releases will be
+infrequent and deliberate, this approach ensures artefacts are built
+once and reused, with the website updating only when there's a new
+release.
+
+#### Topiary Book
+
+- **Build location**: Website CI (as a subtask)
+- **Artefact storage**: n/a (not a standalone release artefact)
+- **Versioning**: Latest from default branch
+- **Website trigger**: Any commit to the default branch of the main
+  Topiary repository that modifies book source files (path filter:
+  `docs/book/**`) triggers the website CI via `repository_dispatch`
+
+The Topiary Book is living documentation that should stay current with
+the main repository. Building it on-demand in the website CI avoids
+duplication and ensures the website always reflects the latest
+documentation.
+
 ## Alternatives considered
 
 Leave the Topiary repository where it is; i.e., do nothing. However,
@@ -133,27 +168,3 @@ warning, like it does when repository names change.
 
 Documentation will remain under the Topiary repository, so there will be
 no impact.
-
-## Unresolved questions
-
-- For the broken out subcomponents that are dependencies of the website,
-  should we:
-
-  1. Build the subcomponents in the broken out repository's CI and let
-     the website pull in the latest release, when its CI builds?
-
-  2. Or: When the website's CI builds, checkout the appropriate
-     subcomponents and build them as subtasks?
-
-  This question is focused on the Topiary playground.
-
-  For the Topiary Book, option (2) is probably the only appropriate
-  strategy because the Book is not manifested as a release artefact (and
-  cannot be without interfering with Topiary's `dist` release process).
-
-- Relatedly, when dependencies of the website are changed, how can we
-  trigger a new build of the website (e.g., if the Topiary Book is
-  updated, that should reflected on the website)? I believe GitHub
-  Actions _can_ trigger other actions across repositories, but this
-  needs to be carefully looked into; we shouldn't expect contributors to
-  have to make cousin PRs in separate repositories manually.

--- a/buds/bud-1.md
+++ b/buds/bud-1.md
@@ -1,0 +1,86 @@
+<!----------------------------------------------------------------------
+This is a template for creating new BUDs (Blueprints for Upcoming
+Development). Copy this file to buds/bud-[number].md (or use TBD for the
+number initially) and fill in each section.
+----------------------------------------------------------------------->
+
+---
+bud: 1 (TBD)
+title: The great GitHub migration
+author: "@Xophmeister"
+pr: 4
+---
+
+# The great GitHub migration
+
+## Summary
+
+We have been given the green light to move the Topiary repository from
+the Tweag GitHub organisation to our new Topiary organisation, providing
+we maintain appropriate branding. The move also gives us an opportunity
+to break out some of the peripheral subcomponents of the Topiary
+repository into their own, dedicated repositories.
+
+## Motivation
+
+- Having all Topiary repositories under one organisation is clearer and
+  aids discovery, at the expense of current users having to update links
+  and remotes, etc.
+
+- The Topiary website is orthogonal to the Topiary codebase, so should
+  certainly be broken out into its own repository. Similar arguments can
+  be made for:
+
+  - The Topiary playground: Not currently under active development, but
+    effectively another client of the Topiary core library.
+
+  - The Topiary Book and manpages: These should be synchronised with the
+    codebase, so the decoupling argument is weaker, but keeping them
+    separate _may_ motivate better code documentation, keeping the Book
+    as user documentation.
+
+  - [topiary-opam][https://github.com/tweag/topiary-opam]: This is
+    separate from the Topiary repository, but will probably need to be
+    updated if the migration goes ahead and, indeed, is a target for
+    migration itself.
+
+There may be infrastructural changes required for correctly migrate
+(e.g., DNS, Cachix, etc.)
+
+## Proposed design
+
+{TODO: Still under discussion}
+
+## Alternatives considered
+
+Leave the Topiary repository where it is; i.e., do nothing. {TODO: Still
+under discussion}
+
+## Drawbacks
+
+- Website downtime during the migration
+- Current users would have to update links and remotes
+- The decoupling proposal would increase the complexity (warranting a
+  multiphase migration) and probably increase the website downtime
+- DNS changes take a while to action, which will also impact website
+  downtime
+- We risk losing access to Tweag infrastructure (e.g., Cachix)
+
+## Backwards compatibility
+
+If current users don't update links/remotes, that may be confusing for
+them. We can mitigate this to a certain extent by broadcasting it on
+Discord. GitHub _may_ keep the old remote active for a limited time, and
+display a warning, like it does when repository names change.
+
+## Testing strategy
+
+{TODO: Still under discussion}
+
+## Documentation impact
+
+{TODO: Still under discussion}
+
+## Unresolved questions
+
+{TODO: Still under discussion}


### PR DESCRIPTION
# Topiary BUD-1

## Checklist

<!--
Ideas for new features and enhancements to Topiary should first be
discussed: https://github.com/topiary/bud/discussions/categories/new-buds

Please complete the following sections:
-->

- [x] I have discussed this BUD proposal at: #3
- [x] I have followed the [guidance for new BUDs](https://github.com/topiary/bud/blob/trunk/README.md)

## Description

Motivation and plan to migrate Topiary and related repositories from the Tweag GitHub organisation to our new Topiary organisation. Using the opportunity to break out periphery subcomponents from the main Topiary repository.

---

## Implementation checklist

- [x] Access
  - [x] GitHub
    - [x] `tweag/topiary`
    - [x] `tweag/topiary-opam`
  - [x] Cachix
- [x] Migration
  - [x] Announce on Discord: Migration to start 2026-01-26
  - [x] `tweag/topiary` --> `topiary/topiary`
    - [x] Reinstall Renovate
  - [x] `tweag/topiary-opam` --> `topiary/topiary-opam`
    - [x] Set branch protection
- [x] Break out subcomponents
  - [x] `mdbook-manmunge`
    - [x] Codebase broken out into https://github.com/topiary/mdbook-manmunge
      - [x] Set branch protection
    - [x] https://github.com/topiary/topiary/pull/1172 
  - [x] Topiary playground
    - [x] Codebase broken out into https://github.com/topiary/playground
      - [x] Set branch protection
      - [x] https://github.com/topiary/playground/pull/1
    - [x] https://github.com/topiary/topiary/pull/1174
  - [x] Website
    - [x] Codebase broken out into https://github.com/topiary/www
      - [x] Set branch protection
      - [x] https://github.com/topiary/www/pull/1
    - [x] https://github.com/topiary/topiary/pull/1191
    - [x] https://github.com/topiary/playground/pull/2
- [x] Finalisation
  - [x] DNS record update
  - [x] Testing
  - [x] Announce completion on Discord: Migration complete 2026-02-26